### PR TITLE
Module SCSS 설정 작성

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -159,11 +159,21 @@ module.exports = {
         publisherId: metaConfig.ad,
       },
     },
+    {
+      resolve: `gatsby-plugin-sass`,
+      options: {
+        cssLoaderOptions: {
+          esModule: true,
+          modules: {
+            namedExport: false,
+          },
+        },
+      },
+    },
     `gatsby-plugin-image`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-offline`,
-    `gatsby-plugin-sass`,
     `gatsby-plugin-lodash`,
     `gatsby-plugin-sitemap`,
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "gatsby-starter-bee",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@mdx-js/react": "^2.3.0",
         "gatsby": "^5.13.1",
@@ -70,6 +71,7 @@
         "eslint": "^5.14.1",
         "eslint-plugin-react": "^7.11.1",
         "fs-extra": "^7.0.1",
+        "gatsby-plugin-dts-css-modules": "^3.0.0",
         "gatsby-post-gen": "^1.0.0",
         "gray-matter": "^4.0.2",
         "inquirer": "^6.2.2",
@@ -8632,6 +8634,15 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/dts-css-modules-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dts-css-modules-loader/-/dts-css-modules-loader-2.0.0.tgz",
+      "integrity": "sha512-eheqA1F2uVKs8A5BQTpPyg5wwLE2mictYjN0atJX/VLVpXDr9Xx1bqM9W5piQi9zp/CUkMBCBw+a2zr1TxFtQw==",
+      "dev": true,
+      "peerDependencies": {
+        "css-loader": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -10839,6 +10850,22 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-dts-css-modules": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-dts-css-modules/-/gatsby-plugin-dts-css-modules-3.0.0.tgz",
+      "integrity": "sha512-ZDTNPvJOXbuKf1my1AhEqqMFetuH5IYxz73k5GK8VYFNAsy8rraIm0OxMHsYjaR/8J5dpm4mrYAJf9++5bjzHg==",
+      "dev": true,
+      "dependencies": {
+        "dts-css-modules-loader": "2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": ">= 3",
+        "joi": "^17.0.0"
       }
     },
     "node_modules/gatsby-plugin-feed": {

--- a/src/components/post-date/index.module.scss
+++ b/src/components/post-date/index.module.scss
@@ -1,4 +1,4 @@
-.post-date {
+.postDate {
   text-align: right;
   font-size: 12px;
   font-style: italic;

--- a/src/components/post-date/index.tsx
+++ b/src/components/post-date/index.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react'
-import './index.scss'
+import styles from './index.module.scss'
 
 interface PostDateProps {
   date: string
 }
 
 export const PostDate: FC<PostDateProps> = ({ date }) => {
-  return <p className="post-date">{date}</p>
+  return <p className={styles.postDate}>{date}</p>
 }

--- a/src/types/scss.d.ts
+++ b/src/types/scss.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: { [className: string]: string }
+  export default content
+}


### PR DESCRIPTION
- CSS 오버라이딩 이슈 때문에 빌드 시 최적화 이슈가 상당히 많이 발생하고 있는 상황 
  -> 따라서 네임스페이스 적용 위해 Module SCSS 사용할 수 있도록 `gatsby-config.ts` 코드 일부 수정
- `post-date` 컴포넌트에서 Module SCSS 정상동작하는 것 확인하였음

[TMI]
- `gatsby-plugin-sass` 공식문서에서는 gatsby-config.ts에 플러그인을 추가하기만 하면 바로 Module SCSS를 사용할 수 있다고 하였으나, 이러한 설명과는 달리 해당 플러그인 설정을 일부 추가해주어야만 Module SCSS가 사용가능하였음.